### PR TITLE
fmt::printf requires <fmt/prinf.h> header

### DIFF
--- a/Conan.VisualStudio.Examples/ExampleCLI/ExampleCLI/ExampleCLI.cpp
+++ b/Conan.VisualStudio.Examples/ExampleCLI/ExampleCLI/ExampleCLI.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <fmt/format.h>
+#include <fmt/printf.h>
 
 int main()
 {


### PR DESCRIPTION
closes #49 