### PR TITLE
Feature: specify compiler cpp std with cpp language standard

### DIFF
--- a/Conan.VisualStudio.Core/ConanConfiguration.cs
+++ b/Conan.VisualStudio.Core/ConanConfiguration.cs
@@ -9,6 +9,7 @@ namespace Conan.VisualStudio.Core
         public string CompilerVersion { get; set; }
         public string InstallPath { get; set; }
         public string RuntimeLibrary { get; set; }
+        public string CppStd { get; set; }
 
         public override string ToString()
         {

--- a/Conan.VisualStudio.Core/ConanConfiguration.cs
+++ b/Conan.VisualStudio.Core/ConanConfiguration.cs
@@ -19,6 +19,8 @@ namespace Conan.VisualStudio.Core
                            $"compiler version: {CompilerVersion};";
             if (RuntimeLibrary != null)
                 value += $", runtime library: {RuntimeLibrary}";
+            if (CppStd != null)
+                value += $", compiler cppstd: {CppStd}";
             return value;
         }
     }

--- a/Conan.VisualStudio.Core/ConanRunner.cs
+++ b/Conan.VisualStudio.Core/ConanRunner.cs
@@ -79,6 +79,10 @@ namespace Conan.VisualStudio.Core
                 {
                     settingValues = settingValues.Concat(new[] { ("compiler.runtime", configuration.RuntimeLibrary) }).ToArray();
                 }
+                if (configuration.CppStd != null)
+                {
+                    settingValues = settingValues.Concat(new[] { ("compiler.cppstd", configuration.CppStd) }).ToArray();
+                }
 
                 var settings = string.Join(" ", settingValues.Where(pair => pair.Item2 != null).Select(pair =>
                 {

--- a/Conan.VisualStudio.Core/VCInterfaces/IVCConfiguration.cs
+++ b/Conan.VisualStudio.Core/VCInterfaces/IVCConfiguration.cs
@@ -22,6 +22,8 @@ namespace Conan.VisualStudio.Core.VCInterfaces
 
         string Toolset { get; }
 
+        string CppStd { get; }
+
         string Evaluate(string value);
 
         void AddPropertySheet(string sheet);

--- a/Conan.VisualStudio.VCProjectWrapper/VCConfigurationWrapper.cs
+++ b/Conan.VisualStudio.VCProjectWrapper/VCConfigurationWrapper.cs
@@ -35,7 +35,7 @@ namespace Conan.VisualStudio.VCProjectWrapper
 
         private static string LanguageStandardToCppStd(string LanguageStandard)
         {
-            switch (LanguageStandard)
+            switch (LanguageStandard?.ToLower())
             {
                 case "stdcpplatest":
                     return "20";

--- a/Conan.VisualStudio.VCProjectWrapper/VCConfigurationWrapper.cs
+++ b/Conan.VisualStudio.VCProjectWrapper/VCConfigurationWrapper.cs
@@ -33,6 +33,24 @@ namespace Conan.VisualStudio.VCProjectWrapper
             }
         }
 
+        private static string LanguageStandardToCppStd(string LanguageStandard)
+        {
+            switch (LanguageStandard)
+            {
+                case "stdcpplatest":
+                    return "20";
+                case "stdcpp17":
+                    return "17";
+                case "stdcpp14":
+                    return "14";
+                case "default":
+                    return null;
+                default:
+                    throw new NotSupportedException(
+                        $"Language Standard {LanguageStandard} is not supported by the Conan plugin");
+            }
+        }
+
         public string ProjectDirectory => _configuration.project.ProjectDirectory;
 
         public string ProjectName => _configuration.project.Name;
@@ -58,6 +76,16 @@ namespace Conan.VisualStudio.VCProjectWrapper
             {
                 IVCRulePropertyStorage generalSettings = _configuration.Rules.Item("ConfigurationGeneral");
                 return generalSettings.GetEvaluatedPropertyValue("PlatformToolset");
+            }
+        }
+
+        public string CppStd
+        {
+            get
+            {
+                IVCRulePropertyStorage generalSettings = _configuration.Rules.Item("ConfigurationGeneral");
+                return LanguageStandardToCppStd(
+                    generalSettings.GetEvaluatedPropertyValue("LanguageStandard"));
             }
         }
 

--- a/Conan.VisualStudio.VCProjectWrapper/VCConfigurationWrapper.cs
+++ b/Conan.VisualStudio.VCProjectWrapper/VCConfigurationWrapper.cs
@@ -44,10 +44,39 @@ namespace Conan.VisualStudio.VCProjectWrapper
                 case "stdcpp14":
                     return "14";
                 case "default":
+                case null:
                     return null;
                 default:
                     throw new NotSupportedException(
                         $"Language Standard {LanguageStandard} is not supported by the Conan plugin");
+            }
+        }
+
+        private string GetEvaluatedPropertyValueFromTool(string propertyName, string toolName)
+        {
+            var properties = _configuration.Tools.Item(toolName) as IVCRulePropertyStorage;
+
+            try
+            {
+                return properties?.GetEvaluatedPropertyValue(propertyName);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private string GetEvaluatedPropertyValueFromRule(string propertyName, string ruleName)
+        {
+            var properties = _configuration.Rules.Item(ruleName) as IVCRulePropertyStorage;
+
+            try
+            {
+                return properties?.GetEvaluatedPropertyValue(propertyName);
+            }
+            catch
+            {
+                return null;
             }
         }
 
@@ -83,9 +112,25 @@ namespace Conan.VisualStudio.VCProjectWrapper
         {
             get
             {
-                IVCRulePropertyStorage generalSettings = _configuration.Rules.Item("ConfigurationGeneral");
-                return LanguageStandardToCppStd(
-                    generalSettings.GetEvaluatedPropertyValue("LanguageStandard"));
+                var LanguageStandard = GetEvaluatedPropertyValueFromTool("LanguageStandard",
+                    "VCCLCompilerTool");
+
+                if (LanguageStandard != null)
+                {
+                    return LanguageStandardToCppStd(LanguageStandard);
+                }
+
+                LanguageStandard = GetEvaluatedPropertyValueFromRule("LanguageStandard", "CL");
+
+                if (LanguageStandard != null)
+                {
+                    return LanguageStandardToCppStd(LanguageStandard);
+                }
+
+                LanguageStandard = GetEvaluatedPropertyValueFromRule("LanguageStandard",
+                    "ConfigurationGeneral");
+
+                return LanguageStandardToCppStd(LanguageStandard);
             }
         }
 

--- a/Conan.VisualStudio/Services/VcProjectService.cs
+++ b/Conan.VisualStudio/Services/VcProjectService.cs
@@ -173,7 +173,8 @@ namespace Conan.VisualStudio.Services
                 CompilerToolset = configuration.Toolset,
                 CompilerVersion = VisualStudioVersion.ToString(),
                 InstallPath = installPath,
-                RuntimeLibrary = configuration.RuntimeLibrary
+                RuntimeLibrary = configuration.RuntimeLibrary,
+                CppStd = configuration.CppStd
             };
         }
     }


### PR DESCRIPTION
Take the value set for C++ Language Standard, in the project's properties page, and use it to define a `-s compiler.cppstd` setting during conan install.