### PR TITLE
Refresh Visual Studio property sheets list before adding a new one (resolving issue #128)

### DIFF
--- a/Conan.VisualStudio.Core/Conan.VisualStudio.Core.csproj
+++ b/Conan.VisualStudio.Core/Conan.VisualStudio.Core.csproj
@@ -39,6 +39,11 @@
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.Shell.15.0, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/Conan.VisualStudio.Core/VCInterfaces/IVCConfiguration.cs
+++ b/Conan.VisualStudio.Core/VCInterfaces/IVCConfiguration.cs
@@ -3,12 +3,16 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Conan.VisualStudio.Core.VCInterfaces
 {
     public interface IVCConfiguration
     {
         string ProjectDirectory { get; }
+
+        string ProjectFileName { get; }
 
         string ProjectName { get; }
 
@@ -24,7 +28,9 @@ namespace Conan.VisualStudio.Core.VCInterfaces
 
         string Evaluate(string value);
 
-        bool AddPropertySheet(string sheet);
+        void AddPropertySheet(string sheet, string projectFileName);
+
+        bool IsPropertySheetPresent(string sheet);
 
         void CollectIntelliSenseInfo();
 

--- a/Conan.VisualStudio.Core/VCInterfaces/IVCConfiguration.cs
+++ b/Conan.VisualStudio.Core/VCInterfaces/IVCConfiguration.cs
@@ -24,7 +24,7 @@ namespace Conan.VisualStudio.Core.VCInterfaces
 
         string Evaluate(string value);
 
-        void AddPropertySheet(string sheet);
+        bool AddPropertySheet(string sheet);
 
         void CollectIntelliSenseInfo();
 

--- a/Conan.VisualStudio.Core/VCInterfaces/IVCProject.cs
+++ b/Conan.VisualStudio.Core/VCInterfaces/IVCProject.cs
@@ -10,8 +10,16 @@ namespace Conan.VisualStudio.Core.VCInterfaces
     {
         string ProjectDirectory { get; }
 
+        string FullPath { get; }
+
+        string Guid { get; }
+
+        bool Saved { get; }
+
         List<IVCConfiguration> Configurations { get; }
 
         IVCConfiguration ActiveConfiguration { get; }
+
+        void Save();
     }
 }

--- a/Conan.VisualStudio.VCProjectWrapper/Conan.VisualStudio.VCProjectWrapper14.csproj
+++ b/Conan.VisualStudio.VCProjectWrapper/Conan.VisualStudio.VCProjectWrapper14.csproj
@@ -39,6 +39,21 @@
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="envdte100, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="envdte80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="envdte90, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="Microsoft.Build" />
+    <Reference Include="Microsoft.VisualStudio.Shell.15.0, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.VCProject, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\packages\VSSDK_VCProject.14.0.0\lib\Microsoft.VisualStudio.VCProject.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>

--- a/Conan.VisualStudio.VCProjectWrapper/Conan.VisualStudio.VCProjectWrapper14.csproj
+++ b/Conan.VisualStudio.VCProjectWrapper/Conan.VisualStudio.VCProjectWrapper14.csproj
@@ -54,6 +54,9 @@
     <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.VisualStudio.Shell.15.0, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.VCProject, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\packages\VSSDK_VCProject.14.0.0\lib\Microsoft.VisualStudio.VCProject.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>

--- a/Conan.VisualStudio.VCProjectWrapper/Conan.VisualStudio.VCProjectWrapper15.csproj
+++ b/Conan.VisualStudio.VCProjectWrapper/Conan.VisualStudio.VCProjectWrapper15.csproj
@@ -39,6 +39,21 @@
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="envdte100, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="envdte80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="envdte90, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="Microsoft.Build" />
+    <Reference Include="Microsoft.VisualStudio.Shell.15.0, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.VCProject, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>

--- a/Conan.VisualStudio.VCProjectWrapper/Conan.VisualStudio.VCProjectWrapper15.csproj
+++ b/Conan.VisualStudio.VCProjectWrapper/Conan.VisualStudio.VCProjectWrapper15.csproj
@@ -54,6 +54,9 @@
     <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.VisualStudio.Shell.15.0, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.VCProject, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>

--- a/Conan.VisualStudio.VCProjectWrapper/VCConfigurationWrapper.cs
+++ b/Conan.VisualStudio.VCProjectWrapper/VCConfigurationWrapper.cs
@@ -68,6 +68,10 @@ namespace Conan.VisualStudio.VCProjectWrapper
 
         public void AddPropertySheet(string sheet)
         {
+            //This Add/Remove/Add ensures that Visual Studio refreshes its property sheets even if they were not accessible files 
+            //before conan install
+            VCPropertySheet VCsheet = _configuration.AddPropertySheet(sheet);
+            _configuration.RemovePropertySheet(VCsheet);
             _configuration.AddPropertySheet(sheet);
         }
 

--- a/Conan.VisualStudio.VCProjectWrapper/VCProjectWrapper.cs
+++ b/Conan.VisualStudio.VCProjectWrapper/VCProjectWrapper.cs
@@ -1,33 +1,52 @@
 using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Conan.VisualStudio.Core.VCInterfaces;
+using EnvDTE;
 using Microsoft.VisualStudio.VCProjectEngine;
 
 namespace Conan.VisualStudio.VCProjectWrapper
 {
     public class VCProjectWrapper : IVCProject
     {
-        private readonly VCProject _project;
+        private readonly VCProject _vcProject;
+        private readonly Project _project;
         public VCProjectWrapper(object project)
         {
-            _project = project as VCProject;
+            _project = project as Project;
+            _vcProject = _project.Object as VCProject;
         }
-        public string ProjectDirectory => _project.ProjectDirectory;
+        public string ProjectDirectory => _vcProject.ProjectDirectory;
 
         public List<IVCConfiguration> Configurations
         {
             get
             {
                 List<IVCConfiguration> configurations = new List<IVCConfiguration>();
-                foreach (VCConfiguration configuration in _project.Configurations)
+                foreach (VCConfiguration configuration in _vcProject.Configurations)
                     configurations.Add(new VCConfigurationWrapper(configuration));
                 return configurations;
             }
         }
 
-        public IVCConfiguration ActiveConfiguration => new VCConfigurationWrapper(_project.ActiveConfiguration);
+        public IVCConfiguration ActiveConfiguration => new VCConfigurationWrapper(_vcProject.ActiveConfiguration);
+
+        string IVCProject.Guid => _vcProject.ProjectGUID;
+
+        string IVCProject.FullPath {
+            get {
+                return Path.Combine(_vcProject.ProjectDirectory, _vcProject.ProjectFile);
+            }
+        }
+
+        bool IVCProject.Saved => _project.Saved;
+
+        void IVCProject.Save()
+        {
+            _project.Save();
+        }
     }
 }

--- a/Conan.VisualStudio/Services/ConanService.cs
+++ b/Conan.VisualStudio/Services/ConanService.cs
@@ -41,15 +41,6 @@ namespace Conan.VisualStudio.Services
 
             configuration.AdditionalDependencies = configuration.AdditionalDependencies.Replace("$(NOINHERIT)", "");
 
-            foreach (IVCPropertySheet sheet in configuration.PropertySheets)
-            {
-                if (ConanPathHelper.NormalizePath(sheet.PropertySheetFile) == ConanPathHelper.NormalizePath(absPropFilePath))
-                {
-                    string msg = $"[Conan.VisualStudio] Property sheet '{absPropFilePath}' already added to project {configuration.ProjectName}";
-                    Logger.Log(msg);
-                    return;
-                }
-            }
             configuration.AddPropertySheet(relativePropFilePath);
             Logger.Log($"[Conan.VisualStudio] Property sheet '{absPropFilePath}' added to project {configuration.ProjectName}");
             configuration.CollectIntelliSenseInfo();

--- a/Conan.VisualStudio/Services/IConanService.cs
+++ b/Conan.VisualStudio/Services/IConanService.cs
@@ -9,6 +9,8 @@ namespace Conan.VisualStudio.Services
 {
     public interface IConanService
     {
+        List<string> RefreshingProjects { get; }
+
         Task IntegrateAsync(IVCProject vcProject);
 
         Task<bool> InstallAsync(IVCProject vcProject);

--- a/Conan.VisualStudio/Services/VcProjectService.cs
+++ b/Conan.VisualStudio/Services/VcProjectService.cs
@@ -52,7 +52,7 @@ namespace Conan.VisualStudio.Services
 
             var instance = AppDomain.CurrentDomain.CreateInstanceFromAndUnwrap(path,
                 "Conan.VisualStudio.VCProjectWrapper.VCProjectWrapper",
-                false, BindingFlags.Default, null, new[] { project.Object }, null, null);
+                false, BindingFlags.Default, null, new[] { project }, null, null);
 
             return instance as IVCProject;
         }

--- a/Conan.VisualStudio/VSConanPackage.cs
+++ b/Conan.VisualStudio/VSConanPackage.cs
@@ -76,7 +76,7 @@ namespace Conan.VisualStudio
             _vcProjectService = new VcProjectService();
             _settingsService = new VisualStudioSettingsService(this);
             _errorListService = new ErrorListService();
-            _conanService = new ConanService(_settingsService, _errorListService, _vcProjectService, _solution);
+            _conanService = new ConanService(_settingsService, _errorListService, _vcProjectService, _solution, _dte);
 
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 


### PR DESCRIPTION
This workaround corrects issue #128 
I didn't find an elegant way to do it from DTE. See my [comment](https://github.com/conan-io/conan-vs-extension/issues/128#issuecomment-769759105) in issue #128