### PR TITLE
feature: Add config button to disable extension

### DIFF
--- a/BuildEventsHandler.cs
+++ b/BuildEventsHandler.cs
@@ -33,7 +33,12 @@ namespace conan_vs_extension
             // We always overrwrite the script for the prebuild event
             // the ps1 is always overwritten but the event is only added if no conan_install.ps1 is found
             // in the prebuild events
-            ProjectConfigurationManager.SaveConanPrebuildEventsAllConfig(invokedProject);
+            if (GlobalSettings.ConanExtensionEnabled) {
+                ProjectConfigurationManager.SaveConanPrebuildEventsAllConfig(invokedProject);
+            }
+            else {
+                ProjectConfigurationManager.ClearConanPrebuildEventsAllConfig(invokedProject);
+            }
         }
 
         private void OnBuildProjConfigDone(string Project, string ProjectConfig, string Platform, string SolutionConfig, bool Success)
@@ -43,11 +48,18 @@ namespace conan_vs_extension
             System.Diagnostics.Debug.WriteLine(message);
             Project invokedProject = ProjectConfigurationManager.GetProjectByName(_dte, Project);
             VCConfiguration config = ProjectConfigurationManager.GetVCConfig(invokedProject, ProjectConfig, Platform);
-            // FIXME: the problem with this is that the first time you build
-            // the build is started before this step finishes
-            // maybe we can inject the dependency to the project via a prebuild event? 
-            // with a script?
-            _ = ProjectConfigurationManager.InjectConanDepsAsync(invokedProject, config);
+            if (GlobalSettings.ConanExtensionEnabled)
+            {
+                // FIXME: the problem with this is that the first time you build
+                // the build is started before this step finishes
+                // maybe we can inject the dependency to the project via a prebuild event? 
+                // with a script?
+                _ = ProjectConfigurationManager.InjectConanDepsAsync(invokedProject, config);
+            }
+            else
+            {
+                _ = ProjectConfigurationManager.ExtractConanDepsAsync(invokedProject, config);
+            }
         }
 
         private void OnBuildDone(vsBuildScope Scope, vsBuildAction Action)

--- a/ConanOptionsPage.cs
+++ b/ConanOptionsPage.cs
@@ -8,20 +8,22 @@ using System.Windows.Forms;
 [Guid(GuidList.strConanOptionsPage)]
 public class ConanOptionsPage : DialogPage
 {
+    private bool _enableConanExtension;
     private string _conanExecutablePath;
     private bool _useSystemConan;
 
-    [DisplayName("Executable Path")]
-    [Description("Path to the Conan executable.")]
-    [Editor(typeof(ExecutablePathEditor), typeof(System.Drawing.Design.UITypeEditor))]
-    public string ConanExecutablePath
+    [DisplayName("Activate Conan extension")]
+    [Description("Enable or disable the Conan extension")]
+    public bool EnableConanExtension
     {
-        get => _conanExecutablePath;
+        get => _enableConanExtension;
         set
         {
-            _useSystemConan = false;
-            _conanExecutablePath = value;
-            GlobalSettings.ConanExecutablePath = value;
+            if (_enableConanExtension != value)
+            {
+                _enableConanExtension = value;
+                GlobalSettings.ConanExtensionEnabled = value;
+            }
         }
     }
 
@@ -37,9 +39,28 @@ public class ConanOptionsPage : DialogPage
                 _useSystemConan = value;
                 if (_useSystemConan)
                 {
+                    _conanExecutablePath = "conan";
+                    GlobalSettings.ConanExecutablePath = "conan";
+                }
+                else
+                {
                     _conanExecutablePath = "";
+                    GlobalSettings.ConanExecutablePath = "";
                 }
             }
+        }
+    }
+
+    [DisplayName("Executable Path")]
+    [Description("Path to the Conan executable.")]
+    [Editor(typeof(ExecutablePathEditor), typeof(System.Drawing.Design.UITypeEditor))]
+    public string ConanExecutablePath
+    {
+        get => _conanExecutablePath;
+        set
+        {
+            _conanExecutablePath = value;
+            GlobalSettings.ConanExecutablePath = value;
         }
     }
 

--- a/ConanToolWindowControl.xaml.cs
+++ b/ConanToolWindowControl.xaml.cs
@@ -260,7 +260,7 @@ namespace conan_vs_extension
 
         private bool IsConanInitialized()
         {
-            bool initialized = GlobalSettings.ConanExecutablePath != null && GlobalSettings.ConanExecutablePath.Length > 0;
+            bool initialized = GlobalSettings.ConanExecutablePath.Length > 0 && GlobalSettings.ConanExtensionEnabled;
             return initialized;
         }
 
@@ -273,6 +273,14 @@ namespace conan_vs_extension
 
             PackagesListView.IsEnabled = enabled;
             LibraryHeader.IsEnabled = enabled;
+
+            if (!enabled)
+            {
+                LibrarySearchTextBox.Text = "Click 'configure' to enable or set Conan path -->";
+            } else
+            {
+                LibrarySearchTextBox.Text = "";
+            }
         }
 
 
@@ -280,7 +288,7 @@ namespace conan_vs_extension
         {
             ThreadHelper.ThrowIfNotOnUIThread();
             ShowConfigurationDialog();
-            ToggleUIEnableState(true);
+            ToggleUIEnableState(IsConanInitialized());
 
         }
 

--- a/GlobalSettings.cs
+++ b/GlobalSettings.cs
@@ -7,7 +7,20 @@ using System.Threading.Tasks;
 namespace conan_vs_extension{
     public static class GlobalSettings
     {
+        private static bool _conanExtensionEnabled;
         private static string _conanExecutablePath;
+
+        public static bool ConanExtensionEnabled
+        {
+            get
+            {
+                return _conanExtensionEnabled;
+            }
+            set
+            {
+                _conanExtensionEnabled = value;
+            }
+        }
 
         public static string ConanExecutablePath
         {
@@ -17,17 +30,8 @@ namespace conan_vs_extension{
             }
             set
             {
-
-                if (value == "")
-                {
-                    _conanExecutablePath = "conan";
-                }
-                else
-                {
-                    _conanExecutablePath = value;
-                }
+                _conanExecutablePath = value;
             }
-
         }
     }
 }


### PR DESCRIPTION
Added a new entry in the conan extension global configuration to disable it:
- Removes Conan command of prebuild step.
- Removes conandeps from property sheets.

Improved management of configs to use conan from system or from path, enabling or disabling the elements of the window.
- Added a explanation text in search box when extension is disabled to guide the user to enable it and configure the path to the conan client