### PR TITLE
Fix: Set correct compiler.runtime based on GUI preferences

### DIFF
--- a/ConanProfilesManager.cs
+++ b/ConanProfilesManager.cs
@@ -105,22 +105,20 @@ namespace conan_vs_extension
                             string profileName = getProfileName(vcConfig);
                             string profilePath = System.IO.Path.Combine(conanProjectDirectory, profileName);
 
-                            if (!File.Exists(profilePath))
-                            {
-                                string toolset = vcConfig.Evaluate("$(PlatformToolset)").ToString();
-                                string compilerVersion = getConanCompilerVersion(toolset);
-                                string arch = getConanArch(vcConfig.Evaluate("$(PlatformName)").ToString());
-                                IVCRulePropertyStorage generalRule = vcConfig.Rules.Item("ConfigurationGeneral") as IVCRulePropertyStorage;
-                                string languageStandard = generalRule == null ? null : generalRule.GetEvaluatedPropertyValue("LanguageStandard");
-                                string cppStd = getConanCppstd(languageStandard);
+                            string toolset = vcConfig.Evaluate("$(PlatformToolset)").ToString();
+                            string compilerVersion = getConanCompilerVersion(toolset);
+                            string arch = getConanArch(vcConfig.Evaluate("$(PlatformName)").ToString());
+                            IVCRulePropertyStorage generalRule = vcConfig.Rules.Item("ConfigurationGeneral") as IVCRulePropertyStorage;
+                            string languageStandard = generalRule == null ? null : generalRule.GetEvaluatedPropertyValue("LanguageStandard");
+                            string cppStd = getConanCppstd(languageStandard);
 
-                                var tools = (IVCCollection) vcConfig.Tools;
-                                var vcCTool = (VCCLCompilerTool) tools.Item("VCCLCompilerTool");
+                            var tools = (IVCCollection) vcConfig.Tools;
+                            var vcCTool = (VCCLCompilerTool) tools.Item("VCCLCompilerTool");
 
-                                string runtime = GetRuntimeLibraryType(vcCTool.RuntimeLibrary);
+                            string runtime = GetRuntimeLibraryType(vcCTool.RuntimeLibrary);
 
-                                string buildType = vcConfig.ConfigurationName;
-                                string profileContent = 
+                            string buildType = vcConfig.ConfigurationName;
+                            string profileContent = 
 $@"
 [settings]
 arch={arch}
@@ -134,7 +132,25 @@ compiler.runtime_type={buildType}
 compiler.version={compilerVersion}
 os=Windows
 ";
+
+                            bool shouldWriteFile = true;
+
+                            if (File.Exists(profilePath))
+                            {
+                                string existingProfileContent = File.ReadAllText(profilePath);
+                                if (existingProfileContent == profileContent)
+                                {
+                                    shouldWriteFile = false;
+                                }
+                            }
+
+                            if (shouldWriteFile)
+                            {
                                 File.WriteAllText(profilePath, profileContent);
+                                // We create this .runconan file to indicate that there were changes in the profile and that
+                                // Conan should run, this file is removed by the script that launches conan to reset the state
+                                string runConanFilePath = System.IO.Path.Combine(conanProjectDirectory, ".runconan");
+                                File.WriteAllText(runConanFilePath, ""); 
                             }
                         }
                     }

--- a/ConanProfilesManager.cs
+++ b/ConanProfilesManager.cs
@@ -40,6 +40,22 @@ namespace conan_vs_extension
             return msvcVersionMap[platformToolset];
         }
 
+        private string GetRuntimeLibraryType(runtimeLibraryOption runtimeLibraryValue)
+        {
+            switch (runtimeLibraryValue)
+            {
+                case runtimeLibraryOption.rtMultiThreaded:
+                case runtimeLibraryOption.rtMultiThreadedDebug:
+                    return "static";
+                case runtimeLibraryOption.rtMultiThreadedDLL:
+                case runtimeLibraryOption.rtMultiThreadedDebugDLL:
+                    return "dynamic";
+                default:
+                    return "dynamic";
+            }
+        }
+
+
         private string getConanCppstd(string languageStandard)
         {
             // https://learn.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version?view=msvc-170
@@ -97,7 +113,12 @@ namespace conan_vs_extension
                                 IVCRulePropertyStorage generalRule = vcConfig.Rules.Item("ConfigurationGeneral") as IVCRulePropertyStorage;
                                 string languageStandard = generalRule == null ? null : generalRule.GetEvaluatedPropertyValue("LanguageStandard");
                                 string cppStd = getConanCppstd(languageStandard);
-                                string runtime = vcConfig.Evaluate("$(RuntimeLibrary)").ToString().Contains("DLL") ? "dynamic" : "static";
+
+                                var tools = (IVCCollection) vcConfig.Tools;
+                                var vcCTool = (VCCLCompilerTool) tools.Item("VCCLCompilerTool");
+
+                                string runtime = GetRuntimeLibraryType(vcCTool.RuntimeLibrary);
+
                                 string buildType = vcConfig.ConfigurationName;
                                 string profileContent = 
 $@"

--- a/ConanProfilesManager.cs
+++ b/ConanProfilesManager.cs
@@ -97,6 +97,7 @@ namespace conan_vs_extension
                                 IVCRulePropertyStorage generalRule = vcConfig.Rules.Item("ConfigurationGeneral") as IVCRulePropertyStorage;
                                 string languageStandard = generalRule == null ? null : generalRule.GetEvaluatedPropertyValue("LanguageStandard");
                                 string cppStd = getConanCppstd(languageStandard);
+                                string runtime = vcConfig.Evaluate("$(RuntimeLibrary)").ToString().Contains("DLL") ? "dynamic" : "static";
                                 string buildType = vcConfig.ConfigurationName;
                                 string profileContent = 
 $@"
@@ -105,7 +106,7 @@ arch={arch}
 build_type={buildType}
 compiler=msvc
 compiler.cppstd={cppStd}
-compiler.runtime=dynamic
+compiler.runtime={runtime}
 " +
 $@"
 compiler.runtime_type={buildType}

--- a/ProjectConfigurationManager.cs
+++ b/ProjectConfigurationManager.cs
@@ -132,6 +132,14 @@ if exist "".conan\CONANFILE_%CONAN_BUILD_CONFIG%"" (
     if %errorlevel% equ 1 set performInstall=1
 )
 
+REM Check for the .runconan file that indicates changes in profiles
+
+if exist "".conan\.runconan"" (
+    echo Changes in profiles detected
+    set performInstall=1
+    del "".conan\.runconan""
+)
+
 if %performInstall% equ 1 (
     REM Echo changes detected
     echo Changes detected, executing conan install...


### PR DESCRIPTION
- Set compiler runtime based on Visual Studio settings.
- Trigger conan install when changing profiles contents.

Close https://github.com/conan-io/conan-vs-extension/issues/233