### PR TITLE
Fix: Detect changes correctly in conandata and conanfile

### DIFF
--- a/ConanFileManager.cs
+++ b/ConanFileManager.cs
@@ -15,7 +15,7 @@ namespace conan_vs_extension
             "# To keep your changes, remove these comment lines, but the plugin won't be able to modify your requirements"
         };
 
-        private static bool IsFileCommentGuarded(string path)
+        public static bool IsFileCommentGuarded(string path)
         {
             if (!File.Exists(path)) return false;
 
@@ -54,10 +54,10 @@ namespace conan_vs_extension
             return new string[] { };
         }
 
-        private static void WriteConanfileIfNecessary(string projectDirectory)
+        public static bool ReCreateConanfile(string projectDirectory)
         {
             string conanfilePath = Path.Combine(projectDirectory, "conanfile.py");
-            if (!IsFileCommentGuarded(conanfilePath))
+            if (IsFileCommentGuarded(conanfilePath) || !File.Exists(conanfilePath))
             {
                 string conanfileContents = string.Join(Environment.NewLine,
                     _modifyCommentGuard.Concat(new string[]
@@ -84,26 +84,24 @@ namespace conan_vs_extension
                 );
 
                 File.WriteAllText(conanfilePath, conanfileContents);
+                return true;
             }
+            return false;
         }
 
-        private static void WriteConandataIfNecessary(string projectDirectory)
+        public static bool ReCreateConanData(string projectDirectory)
         {
             string conandataPath = Path.Combine(projectDirectory, "conandata.yml");
-            if (!IsFileCommentGuarded(conandataPath))
+            if (IsFileCommentGuarded(conandataPath) || !File.Exists(conandataPath))
             {
                 string conandataContents = string.Join(Environment.NewLine,
                     _modifyCommentGuard.Concat(new string[] { "requirements:" })
                 );
 
                 File.WriteAllText(conandataPath, conandataContents);
+                return true;
             }
-        }
-
-        public static void WriteNecessaryConanGuardedFiles(string projectDirectory)
-        {
-            WriteConanfileIfNecessary(projectDirectory);
-            WriteConandataIfNecessary(projectDirectory);
+            return false;
         }
 
         public static void WriteNewRequirement(string projectDirectory, string newRequirement)

--- a/ConanFileManager.cs
+++ b/ConanFileManager.cs
@@ -42,6 +42,7 @@ namespace conan_vs_extension
 
                 var deserializer = new DeserializerBuilder()
                     .WithNamingConvention(UnderscoredNamingConvention.Instance)
+                    .IgnoreUnmatchedProperties()
                     .Build();
 
                 var result = deserializer.Deserialize<Requirements>(string.Join(Environment.NewLine, conandataContents));

--- a/ConanFileManager.cs
+++ b/ConanFileManager.cs
@@ -36,7 +36,7 @@ namespace conan_vs_extension
         public static string[] GetConandataRequirements(string projectDirectory)
         {
             string path = Path.Combine(projectDirectory, "conandata.yml");
-            if (IsFileCommentGuarded(path))
+            if (File.Exists(path))
             {
                 string[] conandataContents = File.ReadAllLines(path);
 

--- a/ConanToolWindowControl.xaml.cs
+++ b/ConanToolWindowControl.xaml.cs
@@ -268,8 +268,17 @@ namespace conan_vs_extension
                 string projectFilePath = startupProject.FullName;
                 string projectDirectory = Path.GetDirectoryName(projectFilePath);
 
-                ConanFileManager.WriteNecessaryConanGuardedFiles(projectDirectory);
-                ConanFileManager.WriteNewRequirement(projectDirectory, selectedLibrary + "/" + selectedVersion);
+                ConanFileManager.ReCreateConanfile(projectDirectory);
+
+                string conandataPath = Path.Combine(projectDirectory, "conandata.yml");
+                
+                if (!File.Exists(conandataPath)) {
+                    ConanFileManager.ReCreateConanData(projectDirectory);
+                }
+                
+                if (ConanFileManager.IsFileCommentGuarded(conandataPath)) {
+                    ConanFileManager.WriteNewRequirement(projectDirectory, selectedLibrary + "/" + selectedVersion);
+                }
 
                 _ = ProjectConfigurationManager.SaveConanPrebuildEventsAllConfigAsync(startupProject);
                 VersionsComboBox.IsEnabled = false;

--- a/ConanToolWindowControl.xaml.cs
+++ b/ConanToolWindowControl.xaml.cs
@@ -254,11 +254,6 @@ namespace conan_vs_extension
             var selectedLibrary = LibraryNameLabel.Content.ToString();
             var selectedVersion = VersionsComboBox.SelectedItem.ToString();
 
-            MessageBox.Show($"Requirement {selectedLibrary}/{selectedVersion} added to conandata.yml", "Conan C/C++ Package Manager");
-
-            InstallButton.Visibility = Visibility.Collapsed;
-            RemoveButton.Visibility = Visibility.Visible;
-
             ThreadHelper.ThrowIfNotOnUIThread();
 
             Project startupProject = ProjectConfigurationManager.GetStartupProject(_dte);
@@ -278,10 +273,20 @@ namespace conan_vs_extension
                 
                 if (ConanFileManager.IsFileCommentGuarded(conandataPath)) {
                     ConanFileManager.WriteNewRequirement(projectDirectory, selectedLibrary + "/" + selectedVersion);
+                    MessageBox.Show($"Requirement {selectedLibrary}/{selectedVersion} added to conandata.yml", "Conan C/C++ Package Manager");
+
+                    InstallButton.Visibility = Visibility.Collapsed;
+                    RemoveButton.Visibility = Visibility.Visible;
+                    VersionsComboBox.IsEnabled = false;
+                }
+                else {
+                    MessageBox.Show($"Requirement {selectedLibrary}/{selectedVersion} could not be added to conandata.yml because it was modified. Please, update the file manually.", 
+                                    "Conan C/C++ Package Manager", 
+                                    MessageBoxButton.OK, 
+                                    MessageBoxImage.Warning);
                 }
 
                 _ = ProjectConfigurationManager.SaveConanPrebuildEventsAllConfigAsync(startupProject);
-                VersionsComboBox.IsEnabled = false;
                 FilterListView(LibrarySearchTextBox.Text, ShowPackagesCheckbox.IsChecked ?? false);
             }
         }
@@ -291,11 +296,6 @@ namespace conan_vs_extension
             var selectedLibrary = LibraryNameLabel.Content.ToString();
             var selectedVersion = VersionsComboBox.SelectedItem.ToString();
 
-            MessageBox.Show($"Removing {selectedLibrary} version {selectedVersion}", "Conan C/C++ Package Manager");
-
-            InstallButton.Visibility = Visibility.Visible;
-            RemoveButton.Visibility = Visibility.Collapsed;
-
             ThreadHelper.ThrowIfNotOnUIThread();
 
             Array activeSolutionProjects = _dte.ActiveSolutionProjects as Array;
@@ -304,8 +304,23 @@ namespace conan_vs_extension
             string projectFilePath = activeProject.FullName;
             string projectDirectory = Path.GetDirectoryName(projectFilePath);
 
-            ConanFileManager.RemoveRequirement(projectDirectory, selectedLibrary + "/" + selectedVersion);
-            VersionsComboBox.IsEnabled = true;
+            string conandataPath = Path.Combine(projectDirectory, "conandata.yml");
+
+            if (ConanFileManager.IsFileCommentGuarded(conandataPath)) {
+                ConanFileManager.RemoveRequirement(projectDirectory, selectedLibrary + "/" + selectedVersion);
+                MessageBox.Show($"Removing {selectedLibrary} version {selectedVersion}", "Conan C/C++ Package Manager");
+
+                InstallButton.Visibility = Visibility.Visible;
+                RemoveButton.Visibility = Visibility.Collapsed;
+                VersionsComboBox.IsEnabled = true;
+            }
+            else {
+                MessageBox.Show($"Requirement {selectedLibrary}/{selectedVersion} could not be removed from conandata.yml because it was modified. Please, update the file manually.", 
+                                "Conan C/C++ Package Manager", 
+                                MessageBoxButton.OK, 
+                                MessageBoxImage.Warning);
+            }
+
             FilterListView(LibrarySearchTextBox.Text, ShowPackagesCheckbox.IsChecked ?? false);
         }
 

--- a/ProjectConfigurationManager.cs
+++ b/ProjectConfigurationManager.cs
@@ -123,13 +123,19 @@ REM Check for changes in conandata.yml and conanfile.py
 if exist "".conan\CONANDATA_%CONAN_BUILD_CONFIG%"" (
     echo Checking changes in conandata.yml
     fc ""conandata.yml"" "".conan\CONANDATA_%CONAN_BUILD_CONFIG%"" > nul
-    if %errorlevel% equ 1 set performInstall=1
+    if errorlevel 1 (
+        set performInstall=1
+        echo Changes detected in conandata.yml
+    )
 )
 
 if exist "".conan\CONANFILE_%CONAN_BUILD_CONFIG%"" (
     echo Checking changes in conanfile.py
     fc ""conanfile.py"" "".conan\CONANFILE_%CONAN_BUILD_CONFIG%"" > nul
-    if %errorlevel% equ 1 set performInstall=1
+    if errorlevel 1 (
+        set performInstall=1
+        echo Changes detected in conanfile.py
+    )
 )
 
 REM Check for the .runconan file that indicates changes in profiles

--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="VSConanPackage.4d0379e2-2698-4e66-89de-6ead71165e9f" Version="2.0.5" Language="en-US" Publisher="Conan" />
+        <Identity Id="VSConanPackage.4d0379e2-2698-4e66-89de-6ead71165e9f" Version="2.0.6" Language="en-US" Publisher="Conan" />
         <DisplayName>Conan Extension for Visual Studio</DisplayName>
         <Description xml:space="preserve">Conan Extension for Visual Studio automates the use of the Conan C/C++ package manager for retrieving dependencies within Visual Studio projects.</Description>
         <MoreInfo>https://github.com/conan-io/conan-vs-extension</MoreInfo>


### PR DESCRIPTION
Some more fixes:
- Correct logic for overwritting guarded files
- Don't crash when reading conandata if the file is modified with unknown keys
- Remove the guard comment, and it shows empty lists.
- Remove a requirement from the conandata and click the "list only installed" button; it still shows the removed one.
- Remove the guard comment, click the add requirement button on any reference, and the pop-up window shows that it has been added, but in reality, it hasn't (this last part is expected; what you don't expect is the pop-up window).



Closes: https://github.com/conan-io/conan-vs-extension/issues/242