### PR TITLE
Fix setting msvc compiler in profiles for Visual Studio >= 17.10

### DIFF
--- a/ConanProfilesManager.cs
+++ b/ConanProfilesManager.cs
@@ -31,8 +31,17 @@ namespace conan_vs_extension
             return archMap[platform];
         }
 
-        private string getConanCompilerVersion(string platformToolset)
+        private string getConanCompilerVersion(string platformToolset, string vsVersion)
         {
+            if (Version.TryParse(vsVersion, out Version parsedVersion))
+            {
+                // https://github.com/conan-io/conan/issues/16239
+                if (parsedVersion.Major == 17 && parsedVersion.Minor >= 10)
+                {
+                    return "194";
+                }
+            }
+
             var msvcVersionMap = new Dictionary<string, string>();
             msvcVersionMap["v143"] = "193";
             msvcVersionMap["v142"] = "192";
@@ -106,7 +115,8 @@ namespace conan_vs_extension
                             string profilePath = System.IO.Path.Combine(conanProjectDirectory, profileName);
 
                             string toolset = vcConfig.Evaluate("$(PlatformToolset)").ToString();
-                            string compilerVersion = getConanCompilerVersion(toolset);
+                            string vsVersion = vcConfig.Evaluate("$(MSBuildVersion)").ToString();
+                            string compilerVersion = getConanCompilerVersion(toolset, vsVersion);
                             string arch = getConanArch(vcConfig.Evaluate("$(PlatformName)").ToString());
                             IVCRulePropertyStorage generalRule = vcConfig.Rules.Item("ConfigurationGeneral") as IVCRulePropertyStorage;
                             string languageStandard = generalRule == null ? null : generalRule.GetEvaluatedPropertyValue("LanguageStandard");

--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="VSConanPackage.4d0379e2-2698-4e66-89de-6ead71165e9f" Version="2.0.6" Language="en-US" Publisher="Conan" />
+        <Identity Id="VSConanPackage.4d0379e2-2698-4e66-89de-6ead71165e9f" Version="2.0.7" Language="en-US" Publisher="Conan" />
         <DisplayName>Conan Extension for Visual Studio</DisplayName>
         <Description xml:space="preserve">Conan Extension for Visual Studio automates the use of the Conan C/C++ package manager for retrieving dependencies within Visual Studio projects.</Description>
         <MoreInfo>https://github.com/conan-io/conan-vs-extension</MoreInfo>


### PR DESCRIPTION
Brings a logic similar to the one implemented in https://github.com/conan-io/conan/pull/15588/files that was merged after the breaking change in MSVC versioning: https://devblogs.microsoft.com/cppblog/msvc-toolset-minor-version-number-14-40-in-vs-2022-v17-10/

Closes: https://github.com/conan-io/conan-vs-extension/issues/247
Related to: https://github.com/conan-io/conan/issues/16239