### PR TITLE
Avoid adding .conan folder to projects that may not want to use Conan

### DIFF
--- a/BuildEventsHandler.cs
+++ b/BuildEventsHandler.cs
@@ -36,7 +36,6 @@ namespace conan_vs_extension
 
             if (!IsConanEnabledForProject(Project))
             {
-                System.Diagnostics.Debug.WriteLine($"Skipping OnBuildProjConfigBegin for project {Project} - conandata.yml not found.");
                 return;
             }
 
@@ -55,7 +54,6 @@ namespace conan_vs_extension
 
             if (!IsConanEnabledForProject(Project))
             {
-                System.Diagnostics.Debug.WriteLine($"Skipping OnBuildProjConfigDone for project {Project} - conandata.yml not found.");
                 return;
             }
 

--- a/BuildEventsHandler.cs
+++ b/BuildEventsHandler.cs
@@ -23,11 +23,23 @@ namespace conan_vs_extension
             _buildEvents.OnBuildProjConfigDone += OnBuildProjConfigDone;
         }
 
+        private bool IsConanEnabledForProject(string projectName)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            var project = ProjectConfigurationManager.GetProjectByName(_dte, projectName);
+            return project != null && ProjectConfigurationManager.conandataFileExists(project);
+        }
+
         private void OnBuildProjConfigBegin(string Project, string ProjectConfig, string Platform, string SolutionConfig)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            // here we generate profiles for all projects but we probably should only generate profiles for 
-            // the project marked as startup project
+
+            if (!IsConanEnabledForProject(Project))
+            {
+                System.Diagnostics.Debug.WriteLine($"Skipping OnBuildProjConfigBegin for project {Project} - conandata.yml not found.");
+                return;
+            }
+
             Project invokedProject = ProjectConfigurationManager.GetProjectByName(_dte, Project);
             _profiles_manager.GenerateProfilesForProject(invokedProject);
 
@@ -40,8 +52,13 @@ namespace conan_vs_extension
         private void OnBuildProjConfigDone(string Project, string ProjectConfig, string Platform, string SolutionConfig, bool Success)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            var message = "OnBuildProjConfigDone";
-            System.Diagnostics.Debug.WriteLine(message);
+
+            if (!IsConanEnabledForProject(Project))
+            {
+                System.Diagnostics.Debug.WriteLine($"Skipping OnBuildProjConfigDone for project {Project} - conandata.yml not found.");
+                return;
+            }
+
             Project invokedProject = ProjectConfigurationManager.GetProjectByName(_dte, Project);
             VCConfiguration config = ProjectConfigurationManager.GetVCConfig(invokedProject, ProjectConfig, Platform);
             // FIXME: the problem with this is that the first time you build

--- a/ProjectConfigurationManager.cs
+++ b/ProjectConfigurationManager.cs
@@ -20,7 +20,7 @@ namespace conan_vs_extension
         {
         }
 
-        static private bool conandataFileExists(Project project)
+        public static bool conandataFileExists(Project project)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
             string projectDirectory = System.IO.Path.GetDirectoryName(project.FullName);
@@ -214,13 +214,14 @@ echo No changes detected, skipping conan install...
         public static async Task SaveConanPrebuildEventsAllConfigAsync(Project project)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            await GenerateConanInstallScriptAsync(project); // all the config share the same script
 
             if (!conandataFileExists(project))
             {
                 System.Diagnostics.Debug.WriteLine("conandata.yml not found. Skipping Conan PreBuildEvent.");
                 return;
             }
+
+            await GenerateConanInstallScriptAsync(project); // all the config share the same script
 
             VCProject vcProject = project.Object as VCProject;
             foreach (VCConfiguration vcConfig in (IEnumerable)vcProject.Configurations)


### PR DESCRIPTION
This avoids creating .conan folder or generating files when we are working with projects that have not added a conandata.yaml file which means those are not configured to work with Conan