### PR TITLE
Fix failing to initialize plugin when Conan executable path is null

### DIFF
--- a/ConanOptionsPage.cs
+++ b/ConanOptionsPage.cs
@@ -19,7 +19,7 @@ public class ConanOptionsPage : DialogPage
         get => _conanExecutablePath;
         set
         {
-            _conanExecutablePath = value;
+            _conanExecutablePath = value?.Trim();
             GlobalSettings.ConanExecutablePath = value;
 
             if (value != "conan")

--- a/ConanOptionsPage.cs
+++ b/ConanOptionsPage.cs
@@ -19,7 +19,7 @@ public class ConanOptionsPage : DialogPage
         get => _conanExecutablePath;
         set
         {
-            _conanExecutablePath = value.Trim();
+            _conanExecutablePath = value;
             GlobalSettings.ConanExecutablePath = value;
 
             if (value != "conan")

--- a/GlobalSettings.cs
+++ b/GlobalSettings.cs
@@ -17,7 +17,7 @@ namespace conan_vs_extension{
             }
             set
             {
-                _conanExecutablePath = value.Trim();
+                _conanExecutablePath = value;
             }
 
         }

--- a/GlobalSettings.cs
+++ b/GlobalSettings.cs
@@ -17,7 +17,7 @@ namespace conan_vs_extension{
             }
             set
             {
-                _conanExecutablePath = value;
+                _conanExecutablePath = value?.Trim();
             }
 
         }

--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="VSConanPackage.4d0379e2-2698-4e66-89de-6ead71165e9f" Version="2.0.8" Language="en-US" Publisher="Conan" />
+        <Identity Id="VSConanPackage.4d0379e2-2698-4e66-89de-6ead71165e9f" Version="2.0.9" Language="en-US" Publisher="Conan" />
         <DisplayName>Conan Extension for Visual Studio</DisplayName>
         <Description xml:space="preserve">Conan Extension for Visual Studio automates the use of the Conan C/C++ package manager for retrieving dependencies within Visual Studio projects.</Description>
         <MoreInfo>https://github.com/conan-io/conan-vs-extension</MoreInfo>


### PR DESCRIPTION
Closes: https://github.com/conan-io/conan-vs-extension/issues/260