### PR TITLE
Add support for VS 2026

### DIFF
--- a/ConanProfilesManager.cs
+++ b/ConanProfilesManager.cs
@@ -43,6 +43,7 @@ namespace conan_vs_extension
             }
 
             var msvcVersionMap = new Dictionary<string, string>();
+            msvcVersionMap["v145"] = "195";
             msvcVersionMap["v143"] = "193";
             msvcVersionMap["v142"] = "192";
             msvcVersionMap["v141"] = "191";

--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="VSConanPackage.4d0379e2-2698-4e66-89de-6ead71165e9f" Version="2.0.9" Language="en-US" Publisher="Conan" />
+        <Identity Id="VSConanPackage.4d0379e2-2698-4e66-89de-6ead71165e9f" Version="2.0.10" Language="en-US" Publisher="Conan" />
         <DisplayName>Conan Extension for Visual Studio</DisplayName>
         <Description xml:space="preserve">Conan Extension for Visual Studio automates the use of the Conan C/C++ package manager for retrieving dependencies within Visual Studio projects.</Description>
         <MoreInfo>https://github.com/conan-io/conan-vs-extension</MoreInfo>


### PR DESCRIPTION
According to https://docs.conan.io/2/reference/config_files/settings.html#msvc

Tested with CMake 4.2.3 (> 4 version is needed so the generator for VS 2026 is supported).

Tested with an example using the fmt dependency.